### PR TITLE
Update udev.py

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -203,7 +203,7 @@ def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
+    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info)):
         mdname = udev_info["MD_DEVNAME"]
         if device_is_partition(udev_info):
             # for partitions on named RAID we want to use the raid name, not


### PR DESCRIPTION
Fix for the failure to instantiate MD RAID PartitionDevice caused due to blivet
    git Pull 827. Sysfs path for MDRAID Paritions need not have "/md" existing.
    For example, the sysfs path for the md127p3 partition would be
    /sys/devices/virtual/block/md127/md127p3 and
    /sys/devices/virtual/block/md127/md127p3/md need not exist.

 Signed-off-by: Pooja Yaul <Pooja_Yaul@Dell.com>